### PR TITLE
Fixed large performance overhead from dict lookup

### DIFF
--- a/src/virtac/atip_ioc_entry.py
+++ b/src/virtac/atip_ioc_entry.py
@@ -53,12 +53,18 @@ def main():
             ring_mode = str(os.environ["RINGMODE"])
         except KeyError:
             try:
-                value = caget("SR-CS-RING-01:MODE", format=2)
+                value = caget("SR-CS-RING-01:MODE", timeout=0.5, format=2)
                 ring_mode = value.enums[int(value)]
+                logging.warning(
+                    f"Ring mode not specified, using value from real "
+                    f"machine as default: {value}"
+                )
             except ca_nothing:
                 ring_mode = "I04"
+                logging.warning(f"Ring mode not specified, using default: {ring_mode}")
 
     # Create PVs.
+    logging.debug("Creating ATIP server")
     server = atip_server.ATIPServer(
         ring_mode,
         DATADIR / ring_mode / "limits.csv",

--- a/src/virtac/atip_server.py
+++ b/src/virtac/atip_server.py
@@ -248,6 +248,9 @@ class ATIPServer:
                 )
                 self._in_records[in_record] = ([0], field)
                 self._rb_only_records.append(in_record)
+        self._record_names = (
+            self._get_all_record_names()
+        )  # update complete dict with new records
         print("~*~*Woah, we're halfway there, Wo-oah...*~*~")
 
     def _on_update(self, value, name):
@@ -288,6 +291,9 @@ class ATIPServer:
                                     records in accordance with.
         """
         self._bba_records = self._create_feedback_or_bba_records_from_csv(bba_csv)
+        self._record_names = (
+            self._get_all_record_names()
+        )  # update complete dict with new records
 
     def _create_feedback_records(self, feedback_csv, disable_emittance):
         """Create all the feedback records from the .csv file at the location
@@ -315,6 +321,10 @@ class ATIPServer:
                 "STATUS", initial_value=0, ZRVL=0, ZRST="Successful", PINI="YES"
             )
             self._feedback_records[(0, "emittance_status")] = emit_status_record
+
+        self._record_names = (
+            self._get_all_record_names()
+        )  # update complete dict with new records
 
     def _create_feedback_or_bba_records_from_csv(
         self, csv_file
@@ -405,7 +415,7 @@ class ATIPServer:
             input_records = []
             for pv in input_pvs:
                 try:
-                    input_records.append(self._get_all_record_names()[pv])
+                    input_records.append(self._record_names[pv])
                 except KeyError:
                     input_records.append(caget_mask(pv))
             # Create output record.
@@ -457,6 +467,9 @@ class ATIPServer:
                     "a currently supported type from: 'basic', 'summate', 'collate', "
                     "'inverse', and 'refresh'."
                 )
+        self._record_names = (
+            self._get_all_record_names()
+        )  # update complete dict with new records
 
     def monitor_mirrored_pvs(self):
         """Start monitoring the input PVs for mirrored records, so that they
@@ -511,7 +524,7 @@ class ATIPServer:
             self.monitor_mirrored_pvs()
         self.tune_feedback_status = True
         for line in csv_reader:
-            offset_record = self._get_all_record_names()[line["offset"]]
+            offset_record = self._record_names[line["offset"]]
             self._offset_pvs[line["set pv"]] = offset_record
             mask = callback_offset(self, line["set pv"], offset_record)
             try:
@@ -520,6 +533,9 @@ class ATIPServer:
                 )
             except Exception as e:
                 warn(e, stacklevel=1)
+        self._record_names = (
+            self._get_all_record_names()
+        )  # update complete dict with new records
 
     def stop_all_monitoring(self):
         """Stop monitoring mirrored records and tune feedback offsets."""

--- a/src/virtac/atip_server.py
+++ b/src/virtac/atip_server.py
@@ -114,9 +114,9 @@ class ATIPServer:
         return self._record_names
 
     def _get_all_record_names(self):
-        """A dictionary with all the names of records created by this server
-        as the keys and the corresponding record (and mirror) objects as the
-        values.
+        """Creates and returns a dictionary with all the names of records
+        created by this server as the keys and the corresponding record
+        (and mirror) objects as the values.
         """
         mirrored = []
         for rec_list in self._mirrored_records.values():
@@ -257,7 +257,7 @@ class ATIPServer:
         """The callback function passed to out records, it is called after
         successful record processing has been completed. It updates the out
         record's corresponding in record with the value that has been set and
-        then sets the value to the centralised Pytac lattice. This functions
+        then sets the value to the Pytac lattice. This functions
         needs to be kept FAST as it can be called quickly by CA clients.
 
         Args:
@@ -415,7 +415,7 @@ class ATIPServer:
             input_records = []
             for pv in input_pvs:
                 try:
-                    input_records.append(self._record_names[pv])
+                    input_records.append(self.record_names[pv])
                 except KeyError:
                     input_records.append(caget_mask(pv))
             # Create output record.
@@ -524,7 +524,7 @@ class ATIPServer:
             self.monitor_mirrored_pvs()
         self.tune_feedback_status = True
         for line in csv_reader:
-            offset_record = self._record_names[line["offset"]]
+            offset_record = self.record_names[line["offset"]]
             self._offset_pvs[line["set pv"]] = offset_record
             mask = callback_offset(self, line["set pv"], offset_record)
             try:


### PR DESCRIPTION
Previously everytime the _on_update() function ran due to a PV callback, it would do a dictionary lookup, but instead of reading from a static dict it created the dict by calling all_record_names(). This has been fixed and we instead call the static dict which is created once at startup. This has made the _on_update() function about 63x faster when testing which has resulted in an approx 2x speedup when running against the slow_orbit_feedbacks algorithm.