### PR TITLE
Switch atip and virtac to aioca

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,29 +5,28 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug Unit Test",
-            "type": "debugpy",
-            "request": "launch",
-            "justMyCode": false,
-            "program": "${file}",
-            "purpose": [
-                "debug-test"
-            ],
-            "console": "integratedTerminal",
-            "env": {
-                // Enable break on exception when debugging tests (see: tests/conftest.py)
-                "PYTEST_RAISE": "1",
-            },
-        },
-        {
             "name": "Python Debugger: Virtac",
             "type": "debugpy",
             "request": "launch",
             "program": "/venv/bin/virtac",
             "console": "integratedTerminal",
             "env": {
-                "EPICS_CA_SERVER_PORT": "7064",
-                "EPICS_CA_REPEATER_PORT": "7065",
+                "EPICS_CA_SERVER_PORT": "8064",
+                "EPICS_CA_REPEATER_PORT": "8065",
+            },
+        },
+        {
+            "name": "Python Debugger: ATIP",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "/venv/bin/atip",
+            "console": "integratedTerminal",
+            "args": [
+                "-t"
+            ],
+            "env": {
+                "EPICS_CA_SERVER_PORT": "8064",
+                "EPICS_CA_REPEATER_PORT": "8065",
             },
         },
     ]

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -31,6 +31,3 @@ Initial Setup and Installation
 
 Troubleshooting
 ---------------
-
-Please note that for ATIP to function with Python 3.7 or later, you must
-use Cothread>=2.16.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,7 +88,6 @@ nitpick_ignore = [
     ("py:class", "obj"),
     ("py:class", "class"),
     ("py:class", "at.lattice.lattice_object.Lattice"),
-    ("py:class", "cothread.Event"),
 ]
 
 # Both the class’ and the __init__ method’s docstring are concatenated and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ dependencies = [
     "scipy",
     "pytac>=0.3.0",
     "accelerator-toolbox>=0.2.0",
-    "cothread",
     "softioc",
+    "aioca",
 ]
 
 dynamic = ["version"]

--- a/src/atip/__main__.py
+++ b/src/atip/__main__.py
@@ -1,14 +1,21 @@
 """Interface for ``python -m atip``."""
 
+import asyncio
+import logging
+import random
 from argparse import ArgumentParser
 from collections.abc import Sequence
+
+import pytac
+
+import atip
 
 from . import __version__
 
 __all__ = ["main"]
 
 
-def main(args: Sequence[str] | None = None) -> None:
+async def async_main(args: Sequence[str] | None = None) -> None:
     """Argument parser for the CLI."""
     parser = ArgumentParser()
     parser.add_argument(
@@ -17,7 +24,39 @@ def main(args: Sequence[str] | None = None) -> None:
         action="version",
         version=__version__,
     )
-    parser.parse_args(args)
+    parser.add_argument(
+        "-t",
+        "--run-test",
+        help="Start an endless test of atip",
+        action="store_true",
+    )
+    args = parser.parse_args()
+
+    if args.run_test:
+        # Load the DIAD lattice from Pytac.
+        lat = await pytac.load_csv.load("DIAD")
+        await atip.load_sim.load_from_filepath(lat, "../atip/src/atip/rings/DIAD.mat")
+        # Use the sim by default.
+        lat.set_default_data_source(pytac.SIM)
+        # The initial beam position is zero.
+        print(await lat.get_value("x"))
+
+        # Get the first horizontal corrector magnet and set its current to 1A.
+        hcor1 = lat.get_elements("HSTR")[0]
+        while True:
+            kick: float = random.uniform(0, 2)
+            print(f"Applying x_kick of {kick}")
+            await hcor1.set_value("x_kick", kick, units=pytac.ENG)
+            # Now the x beam position has changed.
+            print(f"New data: {await lat.get_value('x')}")
+            await asyncio.sleep(1)
+
+
+def main(args: Sequence[str] | None = None) -> None:
+    logging.basicConfig()
+    logging.getLogger().setLevel(logging.DEBUG)
+    # Load the AT sim into the Pytac lattice.
+    asyncio.run(async_main(args))
 
 
 if __name__ == "__main__":

--- a/src/atip/load_sim.py
+++ b/src/atip/load_sim.py
@@ -12,7 +12,7 @@ from atip.simulator import ATSimulator
 SIMULATED_FIELDS = {"a1", "b0", "b1", "b2", "x", "y", "f", "x_kick", "y_kick"}
 
 
-def load_from_filepath(
+async def load_from_filepath(
     pytac_lattice, at_lattice_filepath, callback=None, disable_emittance=False
 ):
     """Load simulator data sources onto the lattice and its elements.
@@ -32,12 +32,12 @@ def load_from_filepath(
     at_lattice = at.load.load_mat(
         at_lattice_filepath,
         name=pytac_lattice.name,
-        energy=pytac_lattice.get_value("energy"),
+        energy=await pytac_lattice.get_value("energy"),
     )
-    return load(pytac_lattice, at_lattice, callback, disable_emittance)
+    return await load(pytac_lattice, at_lattice, callback, disable_emittance)
 
 
-def load(pytac_lattice, at_lattice, callback=None, disable_emittance=False):
+async def load(pytac_lattice, at_lattice, callback=None, disable_emittance=False):
     """Load simulator data sources onto the lattice and its elements.
 
     Args:
@@ -58,7 +58,9 @@ def load(pytac_lattice, at_lattice, callback=None, disable_emittance=False):
             f"(AT:{len(at_lattice)} Pytac:{len(pytac_lattice)})."
         )
     # Initialise an instance of the ATSimulator Object.
-    atsim = ATSimulator(at_lattice, callback, disable_emittance)
+    atsim = await ATSimulator.create(
+        at_lattice, callback, disable_emittance
+    )  # TODO: This feels like a wierd place to create the simulator?
     # Set the simulator data source on the Pytac lattice.
     pytac_lattice.set_data_source(ATLatticeDataSource(atsim), pytac.SIM)
     # Load the sim onto each element.

--- a/src/atip/sim_data_sources.py
+++ b/src/atip/sim_data_sources.py
@@ -123,7 +123,7 @@ class ATElementDataSource(pytac.data_source.DataSource):
         else:
             self._fields.append(field)
 
-    def get_value(self, field, handle=None, throw=True):
+    async def get_value(self, field, handle=None, throw=True):
         """Get the value for a field.
 
         Args:
@@ -148,7 +148,7 @@ class ATElementDataSource(pytac.data_source.DataSource):
         # Wait for any outstanding calculations to conclude, to ensure they are
         # complete before a value is returned; if the wait times out then raise
         # an error message or log a warning according to the value of throw.
-        if not self._atsim.wait_for_calculations():
+        if not await self._atsim.wait_for_calculations():
             error_msg = "Check for completion of outstanding calculations timed out."
             if throw:
                 raise ControlSystemException(error_msg)
@@ -160,7 +160,7 @@ class ATElementDataSource(pytac.data_source.DataSource):
         else:
             raise FieldException(f"No field {field} on AT element {self._at_element}.")
 
-    def set_value(self, field, value, throw=None):
+    async def set_value(self, field, value, throw=None):
         """Set the value for a field. The field and value go onto the queue of
         changes on the ATSimulator to be passed to make_change when the queue
         is emptied.
@@ -178,7 +178,7 @@ class ATElementDataSource(pytac.data_source.DataSource):
         """
         if field in self._fields:
             if field in self._set_field_funcs.keys():
-                self._atsim.queue_set(self._make_change, field, value)
+                await self._atsim.queue_set(self._make_change, field, value)
             else:
                 raise HandleException(
                     f"Field {field} cannot be set on element data source {self}."
@@ -413,7 +413,7 @@ class ATLatticeDataSource(pytac.data_source.DataSource):
         """
         return list(self._field_funcs.keys())
 
-    def get_value(self, field, handle=None, throw=True):
+    async def get_value(self, field, handle=None, throw=True):
         """Get the value for a field on the Pytac lattice.
 
         Args:
@@ -438,7 +438,7 @@ class ATLatticeDataSource(pytac.data_source.DataSource):
         # Wait for any outstanding calculations to conclude, to ensure they are
         # complete before a value is returned; if the wait times out then raise
         # an error message or log a warning according to the value of throw.
-        if not self._atsim.wait_for_calculations():
+        if not await self._atsim.wait_for_calculations():
             error_msg = "Check for completion of outstanding calculations timed out."
             if throw:
                 raise ControlSystemException(error_msg)

--- a/src/atip/simulator.py
+++ b/src/atip/simulator.py
@@ -1,11 +1,11 @@
 """Module containing an interface with the AT simulator."""
 
+import asyncio
 import logging
 from dataclasses import dataclass
 from warnings import warn
 
 import at
-import cothread
 import numpy
 from numpy.typing import ArrayLike
 from pytac.exceptions import DataSourceException, FieldException
@@ -73,7 +73,7 @@ class ATSimulator:
     **Attributes**
 
     Attributes:
-        up_to_date (cothread.Event): A flag that indicates if the physics data
+        up_to_date (asyncio.Event): A flag that indicates if the physics data
                                       is up to date with all the changes made
                                       to the AT lattice.
 
@@ -87,18 +87,26 @@ class ATSimulator:
                                         envelope based emittance calculations.
            _lattice_data (LatticeData): calculated physics data
                               function linopt (see at.lattice.linear.py).
-           _queue (cothread.EventQueue): A queue of changes to be applied to
+           _queue (asyncio.Queue): A queue of changes to be applied to
                                           the centralised lattice on the next
                                           recalculation cycle.
-           _paused (cothread.Event): A flag used to temporarily pause the
+           _paused (asyncio.Event): A flag used to temporarily pause the
                                       physics calculations.
-           _calculation_thread (cothread.Thread): A thread to check the queue
-                                                    for new changes to the AT
-                                                    lattice and recalculate the
-                                                    physics data upon a change.
+           _calculation_task (asyncio.Task): A task to check the queue
+                                        for new changes to the AT
+                                        lattice and recalculate the
+                                        physics data upon a change.
     """
 
-    def __init__(self, at_lattice, callback=None, disable_emittance=False):
+    _loop: asyncio.BaseEventLoop
+    _queue: asyncio.Queue
+    _paused: asyncio.Event
+    _quit_thread: asyncio.Event
+    _up_to_date: asyncio.Event
+    _calculation_task: asyncio.Task
+
+    @classmethod
+    async def create(cls, at_lattice, callback=None, disable_emittance=False):
         """
         .. Note:: To avoid errors, the physics data must be initially
            calculated here, during creation, otherwise it could be accidentally
@@ -116,6 +124,7 @@ class ATSimulator:
 
         **Methods:**
         """
+        self = cls()
         if (not callable(callback)) and (callback is not None):
             raise TypeError(
                 f"If passed, 'callback' should be callable, {callback} is not."
@@ -130,17 +139,19 @@ class ATSimulator:
             self._at_lat, self._rp, self._disable_emittance
         )
 
-        # Threading stuff initialisation.
-        self._queue = cothread.EventQueue()
-        # Explicitly manage the cothread Events, so turn off auto_reset.
-        # These are False when reset, True when signalled.
-        self._paused = cothread.Event(auto_reset=False)
-        self._quit_thread = cothread.Event(auto_reset=False)
-        self.up_to_date = cothread.Event(auto_reset=False)
-        self.up_to_date.Signal()
-        self._calculation_thread = cothread.Spawn(self._recalculate_phys_data, callback)
+        self._loop = asyncio.get_event_loop()  # TODO: check a loop is running
+        self._queue = asyncio.Queue()
+        self._paused = asyncio.Event()
+        self._quit_thread = asyncio.Event()
+        self._up_to_date = asyncio.Event()
+        self._up_to_date.set()
 
-    def queue_set(self, func, field, value):
+        self._calculation_task = asyncio.create_task(
+            self._recalculate_phys_data(callback)
+        )  # This task should last the lifetime of the program
+        return self
+
+    async def queue_set(self, func, field, value):
         """Add a change to the queue, to be applied when the queue is emptied.
 
         Args:
@@ -148,31 +159,45 @@ class ATSimulator:
             field (str): The field to be changed.
             value (float): The value to be set.
         """
-        cothread.CallbackResult(self.up_to_date.Reset)
-        cothread.Callback(self._queue.Signal, (func, field, value))
+        await self._queue.put((func, field, value))
+        # If this flag gets cleared while we are recalculating, then it can cause
+        # everything to lock, so we setup a lock between this function and the
+        # recalculate function
+        logging.debug(f"Added task to async queue. qsize={self._queue.qsize()}")
 
-    def _gather_one_sample(self):
+    async def _gather_one_sample(self):
         """If the queue is empty Wait() yields until an item is added. When the
         queue is not empty the oldest change will be removed and applied to the
         AT lattice.
         """
-        apply_change_method, field, value = self._queue.Wait()
+        logging.debug("Waiting for new item in queue")
+        apply_change_method, field, value = await self._queue.get()
         apply_change_method(field, value)
+        logging.debug("Processed item from queue")
 
-    def quit_calculation_thread(self, timeout=10):
+    async def cancel_calculation_task(self, timeout=10):
         """Quit the calculation thread after the current loop is complete."""
-        cothread.CallbackResult(self._quit_thread.Signal)
-        self.trigger_calculation()
-        cothread.CallbackResult(self._calculation_thread.Wait, timeout)
-        # For some reason we have to wait a bit before we can clear the queue.
-        cothread.Sleep(0.1)
-        cothread.CallbackResult(self._queue.Reset)
+        # TODO: Im not really sure what the purpose of this function is, as it
+        # kills all functionality in the virtac and there is no way to restart
+        # it? It also isnt called anywhere, although could be from the python shell
 
-    def _recalculate_phys_data(self, callback):
-        """Target function for the Cothread thread. Recalculates the physics
+        # Do one last calculation and then wait 0.5 seconds to give pvs a chance
+        # to be updated
+        await self.trigger_calculation()
+        await self._quit_thread.set()
+        await asyncio.sleep(0.5)
+        tasks = asyncio.all_tasks()
+        for task in tasks:
+            await task.cancel()
+
+    async def _recalculate_phys_data(self, callback):
+        """Run as a never ending asyncio task. Recalculates the physics
         data dependent on the status of the '_paused' flag and the length of
         the queue. The calculations only take place if '_paused' is False and
-        there are one or more changes on the queue.
+        there are one or more changes on the queue. After doing the recalculations,
+        we set _up_to_date flag to signal this and run any passed callback functions.
+        For VIRTAC, the passed callback is ATIPServer.update_pvs which updates all
+        softioc PVs with the fresh data.
 
         .. Note:: If an error or exception is raised in the running thread then
            it does not continue running so subsequent calculations are not
@@ -187,33 +212,35 @@ class ATSimulator:
             at.AtWarning: any error or exception that was raised in the thread,
                            but as a warning.
         """
-        # Using Cothread Event is only ~4% slower than a normal Boolean but much safer.
-        while not self._quit_thread:
-            logging.debug("Starting recalculation loop")
-            self._gather_one_sample()
-            while self._queue:
-                self._gather_one_sample()
-            if bool(self._paused) is False:
+        logging.debug("Starting recalculation loop")
+        while not self._quit_thread.is_set():
+            await self._gather_one_sample()
+            while not self._queue.empty():
+                await self._gather_one_sample()
+            logging.debug("Recaulculating simulation with new setpoints.")
+            if not self._paused.is_set():
                 try:
                     self._lattice_data = calculate_optics(
                         self._at_lat, self._rp, self._disable_emittance
                     )
                 except Exception as e:
+                    # If an error is found while doing the calculations we dont update
+                    # lattice data. TODO: We currently update the pvs anyway but this
+                    # wont do anything, so could be improved
                     warn(at.AtWarning(e), stacklevel=1)
-                # Signal the up to date flag since the physics data is now up to date.
-                # We do this before the callback is executed in case the callback
-                # checks the flag.
-                self.up_to_date.Signal()
+                # Signal the up to date flag since the physics data is now up to
+                # date. We do this before the callback is executed in case the
+                # callback checks the flag.
+                self._up_to_date.set()
+                logging.debug("Simulation up to date.")
                 if callback is not None:
-                    logging.debug("Executing callback function.")
-                    callback()
+                    logging.debug(f"Executing callback function: {callback.__name__}")
+                    await callback()
                     logging.debug("Callback completed.")
-            # This could cause thread-locking issues if another application using
-            # cothreads is poorly written and running on the same machine, but this
-            # isn't the case with any of the software that currently runs against
-            # ATIP/virtac and it's required for cothread.CallbackResult to play nicely
-            # with Bluesky. So it's a calculated risk until we move away from Cothread.
-            cothread.Yield()
+                # After this point we assume new setpoints have made the data stale. We
+                # cant clear this flag in queue_set() as the callbacks can depend on
+                # this being set.
+                self._up_to_date.clear()
 
     def toggle_calculations(self):
         """Pause or unpause the physics calculations by setting or clearing the
@@ -221,37 +248,38 @@ class ATSimulator:
 
         .. Note:: This does not pause the emptying of the queue.
         """
-        if self._paused:
-            cothread.CallbackResult(self._paused.Reset)
+        if self._paused.is_set():
+            self._paused.clear()
         else:
-            cothread.CallbackResult(self._paused.Signal)
+            self._paused.set()
 
     def pause_calculations(self):
         """Pause the physics calculations by setting the _paused flag.
 
         .. Note:: This does not pause the emptying of the queue.
         """
-        if not self._paused:
-            cothread.CallbackResult(self._paused.Signal)
+        # TODO: These dont currently get called anyway, maybe add a pv to call them?
+        if not self._paused.is_set():
+            self._paused.set()
 
-    def unpause_calculations(self):
+    async def unpause_calculations(self):
         """Unpause the physics calculations by clearing the _paused flag."""
-        if self._paused:
-            cothread.CallbackResult(self._paused.Reset)
-            if not self.up_to_date:
-                self.trigger_calculation()
+        if self._paused.is_set():
+            await self._paused.clear()
+            if not self._up_to_date:
+                await self.trigger_calculation()
 
-    def trigger_calculation(self):
+    async def trigger_calculation(self):
         """Unpause the physics calculations and add a null item to the queue to
         trigger a recalculation.
 
         .. Note:: This method does not wait for the recalculation to complete,
            that is up to the user.
         """
-        self.unpause_calculations()
+        await self.unpause_calculations()
         self.queue_set(lambda *x: None, None, None)
 
-    def wait_for_calculations(self, timeout=10):
+    async def wait_for_calculations(self, timeout=10):
         """Wait until the physics calculations have taken account of all
         changes to the AT lattice, i.e. the physics data is fully up to date.
 
@@ -263,9 +291,9 @@ class ATSimulator:
             concluded, else True.
         """
         try:
-            cothread.CallbackResult(self.up_to_date.Wait, timeout)
+            await asyncio.wait_for(self._up_to_date.wait(), timeout)
             return True
-        except cothread.Timedout:
+        except asyncio.exceptions.TimeoutError:
             return False
 
     # Get lattice related data:

--- a/src/atip/utils.py
+++ b/src/atip/utils.py
@@ -29,7 +29,7 @@ def load_at_lattice(mode="I04", **kwargs):
     return at_lattice
 
 
-def loader(mode="I04", callback=None, disable_emittance=False):
+async def loader(mode="I04", callback=None, disable_emittance=False):
     """Load a unified lattice of the specifed mode.
 
     .. Note:: A unified lattice is a Pytac lattice where the corresponding AT
@@ -46,13 +46,15 @@ def loader(mode="I04", callback=None, disable_emittance=False):
         pytac.lattice.Lattice: A Pytac lattice object with the simulator data
                                 source loaded.
     """
-    pytac_lattice = pytac.load_csv.load(mode, symmetry=24)
+    pytac_lattice = await pytac.load_csv.load(mode, symmetry=24)
     at_lattice = load_at_lattice(
         mode,
         periodicity=1,
-        energy=pytac_lattice.get_value("energy"),
+        energy=await pytac_lattice.get_value("energy"),
     )
-    lattice = atip.load_sim.load(pytac_lattice, at_lattice, callback, disable_emittance)
+    lattice = await atip.load_sim.load(
+        pytac_lattice, at_lattice, callback, disable_emittance
+    )
     return lattice
 
 


### PR DESCRIPTION
This PR will cover the full switch from cothread to asyncio/aioca for both atip and virtac. It requires a broad range of changes, so will be done in staged:

- Majority of asyncio changes to get atip/virtac functional with asyncio/aioca
- Adding of asyncio compliant multiprocessing for running the cpu intensive recalculations
- Improvements to development setup for testing asyncio changes
- TODO: Updating create_csv.py to asyncio
- TODO: Finally update documentation
